### PR TITLE
후보자 DB 저장 기능 구현

### DIFF
--- a/jjikeobang-client/src/pages/Voting.js
+++ b/jjikeobang-client/src/pages/Voting.js
@@ -1,11 +1,13 @@
 import React, { useRef , useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import axios from "axios";
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 
 function Voting(){
+    const location = useLocation();
+    const roomInfo = location.state.room || {};
+    const roomId = roomInfo.roomId;
 
-    const roomId = 1; //일단 정적 코딩 진행
     const [candidates, setCandidates] = useState([]);
 
     useEffect(()=>{

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/controller/CandidateListController.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/controller/CandidateListController.java
@@ -7,8 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import com.jjikeobang.candidate.model.Candidate;
 import com.jjikeobang.candidate.service.CandidateRoomService;

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/controller/InsertCandidateController.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/controller/InsertCandidateController.java
@@ -1,0 +1,57 @@
+package com.jjikeobang.candidate.controller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.jjikeobang.candidate.model.Candidate;
+import com.jjikeobang.candidate.service.CandidateRoomService;
+import com.jjikeobang.candidate.service.CandidateRoomServiceImpl;
+import com.jjikeobang.common.Response;
+import com.jjikeobang.util.JsonUtil;
+
+
+@WebServlet("/candidates") //요청 예시: /candidate?roomId=3 
+public class InsertCandidateController extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+	private final CandidateRoomService candidateRoomService = new CandidateRoomServiceImpl();
+	
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		
+		 try {
+			
+			List<Candidate> candidates = JsonUtil.getInstance().getObjectFromJson(request.getReader(), new TypeReference<List<Candidate>>() {});
+			
+			//유효성 검사
+			if(candidates==null || candidates.size()<1) {
+				throw new IllegalArgumentException("후보자 목록이 비어있습니다.");
+			}
+					 
+			for(Candidate candidate : candidates) {
+				candidateRoomService.insertAllByRoomId(candidate);
+			}
+			
+			Response success = new Response(HttpServletResponse.SC_OK) {};
+			response.getWriter().write(JsonUtil.getInstance().getJsonFromObject(success));
+			 
+		 }catch(IllegalArgumentException e) {
+			 Response error = new Response(HttpServletResponse.SC_BAD_REQUEST,e.getMessage()){};
+			 response.getWriter().write(JsonUtil.getInstance().getJsonFromObject(error));
+		 
+		 }catch(Exception e) {
+			 Response error = new Response(HttpServletResponse.SC_BAD_REQUEST) {};
+			 response.getWriter().write(JsonUtil.getInstance().getJsonFromObject(error));
+			 return;
+		 }
+	
+	}
+
+}

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/repository/CandidateRepository.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/repository/CandidateRepository.java
@@ -11,20 +11,13 @@ public interface CandidateRepository {
 		    "FROM CANDIDATE " +
 		    "WHERE ROOM_ID = ?";
 	
-	//대기중 해당 룸에 등록된 후보자 수정[관리자]
-	String UPDATE_CANDIDATE_FOR_ADMIN = 
-			"UPDATE CANDIDATE " +
-			"SET NAME = ?, DESCRIPTION = ?, PROMISE = ? " +
-			"WHERE CANDIDATE_ID = ? AND ROOM_ID = ?";
-	
-	//대기중 해당 룸에 등록된 후보자 삭제[관리자]
-	String DELETE_CANDIDATE_FOR_ADMIN = 
-			"DELETE FROM CANDIDATE " +
-			"WHERE CANDIDATE_ID = ? AND ROOM_ID = ?";
-	
-	
+	//해당 룸에 등록된 후보자 DB 저장
+	String INSERT_ALL_CANDIDATES_BY_ROOM_ID = 
+			"INSERT INTO CANDIDATE "+
+			"(ROOM_ID,NAME,DESCRIPTION,PROMISE,SIGN_NUMBER,CREATED_AT,VOTE_COUNT) "+
+			"VALUES (?,?,?,?,?,now(),0)";
+
 	List<Candidate> findAllByRoomId(long roomId);
-	boolean updateForAdmin(Candidate candidate);
-	boolean deleteForAdmin(long roomId, long candidateId);
+	int insertCandidate(Candidate candidate);
 
 }

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/repository/CandidateRepositoryImpl.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/repository/CandidateRepositoryImpl.java
@@ -49,18 +49,38 @@ public class CandidateRepositoryImpl implements CandidateRepository {
 		
 		return candidates;
 	}
-	
-	//후보자 수정[관리자]
-	@Override
-	public boolean updateForAdmin(Candidate candidate) {
-		
-		return false;
-	}
-	
-	//후보자 삭제[관리자]
-	@Override
-	public boolean deleteForAdmin(long roomId, long candidateId) {
-		return false;
-	}
 
+	@Override
+	public int insertCandidate(Candidate candidate) {
+		Connection conn = getConnection();
+		PreparedStatement pstmt = null;
+		int rs = 0;
+		
+		try {
+			pstmt = conn.prepareStatement(INSERT_ALL_CANDIDATES_BY_ROOM_ID);
+			pstmt.setLong(1,candidate.getRoomId());
+			pstmt.setString(2, candidate.getName());
+			pstmt.setString(3,candidate.getDescription());
+			pstmt.setString(4, candidate.getPromise());
+			pstmt.setInt(5, candidate.getSignNumber());
+			
+			rs = pstmt.executeUpdate();
+			
+			if(rs>0) {
+				commit(conn);
+			}else {
+				rollback(conn);
+			}
+			
+		}catch(SQLException e) {
+			rollback(conn);
+			e.printStackTrace();
+		}finally {
+			Close(pstmt);
+			Close(conn);
+		}
+		
+		return rs;
+	}
+	
 }

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/service/CandidateRoomService.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/service/CandidateRoomService.java
@@ -4,4 +4,5 @@ import com.jjikeobang.candidate.model.Candidate;
 
 public interface CandidateRoomService {
 	List<Candidate> findAllByRoomId(long roomId);
+	int insertAllByRoomId(Candidate candidate);
 }

--- a/jjikeobang-server/src/main/java/com/jjikeobang/candidate/service/CandidateRoomServiceImpl.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/candidate/service/CandidateRoomServiceImpl.java
@@ -14,4 +14,30 @@ public class CandidateRoomServiceImpl implements CandidateRoomService {
 		return candidateRepository.findAllByRoomId(roomId);
 	}
 
+	@Override
+	public int insertAllByRoomId(Candidate candidate) {
+		//유효성 검사
+		if(candidate.getName() == null || candidate.getName().trim().isEmpty()) {
+			throw new IllegalArgumentException("후보자 이름이 비어있습니다.");
+		}
+		
+		if(candidate.getDescription() == null || candidate.getDescription().trim().isEmpty()) {
+			throw new IllegalArgumentException("후보자 소개가 비어있습니다.");
+		}
+		
+		if(candidate.getPromise()==null || candidate.getPromise().trim().isEmpty()) {
+			throw new IllegalArgumentException("후보자 공약이 비어있습니다.");
+		}
+		
+		if(candidate.getSignNumber()<=0) {
+			throw new IllegalArgumentException("후보자 번호는 1 이상이어야 합니다.");
+		}
+		
+		if(candidate.getRoomId()<=0) {
+			throw new IllegalArgumentException("방 번호는 1 이상이어야 합니다.");
+		}
+			
+		return candidateRepository.insertCandidate(candidate);
+	}
+
 }

--- a/jjikeobang-server/src/main/java/com/jjikeobang/util/JsonUtil.java
+++ b/jjikeobang-server/src/main/java/com/jjikeobang/util/JsonUtil.java
@@ -34,6 +34,11 @@ public class JsonUtil {
     public <T> T getObjectFromJson(Reader json, Class<T> classType) throws IOException {
         return objectMapper.readValue(json, classType);
     }
+    
+    //제네릭 타입 역직렬화를 위한 오버로딩
+    public <T> T getObjectFromJson(Reader json, com.fasterxml.jackson.core.type.TypeReference<T> typeRef) throws IOException {
+        return objectMapper.readValue(json, typeRef);
+    }
 
     public String getJsonFromObject(Object object) throws IOException {
         return objectMapper.writeValueAsString(object);


### PR DESCRIPTION
투표 준비 페이지에서 '투표 시작' 버튼을 클릭 하였을 때, 후보자 DB가 저장되는 기능을 구현하였습니다.

[추가 수정 사항]
1. 후보자 최소 인원 제한 로직 추가
- 후보자 삭제 시, 최소 1명 이상은 유지되도록 삭제 기능을 수정했습니다.

2. room 정보 전달 및 연동 처리
- '투표 시작' 버튼 클릭 시, 해당 room 정보를 함께 전달하고, 투표 시작 페이지에서는 useLocation을 통해 해당 room 정보를 받아와 후보자 목록을 불러올 수 있도록 수정 했습니다.